### PR TITLE
Update jar basename

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -53,6 +53,8 @@ android.libraryVariants.all { variant ->
         exclude '**/Manifest.class'
         exclude '**/Manifest\$*.class'
         exclude '**/BuildConfig.class'
+
+        baseName 'ParseTwitterUtils'
     }
 
     def javadocTask = task("javadoc${variant.name.capitalize()}", type: Javadoc) {


### PR DESCRIPTION
Update jar base name, so when we run

```
./gradlew clean jarRelease
```

the compiled jar name is `ParseTwitterUtils-VERSION.jar` not `library-VERSION.jar`
