### PR TITLE
Convert to HttpURLConnection/OkHttp

### DIFF
--- a/library/src/main/java/com/parse/internal/signpost/basic/DefaultOAuthProvider.java
+++ b/library/src/main/java/com/parse/internal/signpost/basic/DefaultOAuthProvider.java
@@ -31,14 +31,26 @@ public class DefaultOAuthProvider extends AbstractOAuthProvider {
 
     private static final long serialVersionUID = 1L;
 
+    private transient HttpURLConnectionClient httpURLConnectionClient;
+
     public DefaultOAuthProvider(String requestTokenEndpointUrl, String accessTokenEndpointUrl,
             String authorizationWebsiteUrl) {
         super(requestTokenEndpointUrl, accessTokenEndpointUrl, authorizationWebsiteUrl);
+        this.httpURLConnectionClient = HttpURLConnectionClient.create();
     }
 
-    protected HttpRequest createRequest(String endpointUrl) throws MalformedURLException,
-            IOException {
-        HttpURLConnection connection = (HttpURLConnection) new URL(endpointUrl).openConnection();
+    public DefaultOAuthProvider(String requestTokenEndpointUrl, String accessTokenEndpointUrl,
+            String authorizationWebsiteUrl, HttpURLConnectionClient httpURLConnectionClient) {
+        super(requestTokenEndpointUrl, accessTokenEndpointUrl, authorizationWebsiteUrl);
+        this.httpURLConnectionClient = httpURLConnectionClient;
+    }
+
+    public void setHttpURLConnectionClient(HttpURLConnectionClient httpURLConnectionClient) {
+        this.httpURLConnectionClient = httpURLConnectionClient;
+    }
+
+    protected HttpRequest createRequest(String endpointUrl) throws Exception {
+        HttpURLConnection connection = httpURLConnectionClient.open(new URL(endpointUrl));
         connection.setRequestMethod("POST");
         connection.setAllowUserInteraction(false);
         connection.setRequestProperty("Content-Length", "0");

--- a/library/src/main/java/com/parse/internal/signpost/basic/HttpURLConnectionClient.java
+++ b/library/src/main/java/com/parse/internal/signpost/basic/HttpURLConnectionClient.java
@@ -1,0 +1,42 @@
+package com.parse.internal.signpost.basic;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Adapter class to provide HttpURLConnection, using android HttpURLConnection or OkHttp
+ */
+public final class HttpURLConnectionClient {
+    private final boolean isUsingOkHttp;
+    private final Object okUrlFactory;
+    private final Method okUrlFactoryOpen;
+
+    private HttpURLConnectionClient(boolean isUsingOkHttp, Object okUrlFactory, Method okUrlFactoryOpen) {
+        this.isUsingOkHttp = isUsingOkHttp;
+        this.okUrlFactory = okUrlFactory;
+        this.okUrlFactoryOpen = okUrlFactoryOpen;
+    }
+
+    public static HttpURLConnectionClient create() {
+        try {
+            final Class okHttpClientClass = Class.forName("com.squareup.okhttp.OkHttpClient");
+            final Object okHttpClient = okHttpClientClass.getConstructor().newInstance();
+            final Class okUrlFactoryClass = Class.forName("com.squareup.okhttp.OkUrlFactory");
+            final Object okUrlFactory = okUrlFactoryClass.getConstructor(okHttpClientClass).newInstance(okHttpClient);
+            final Method okUrlFactoryOpen = okUrlFactoryClass.getMethod("open", URL.class);
+            return new HttpURLConnectionClient(true, okUrlFactory, okUrlFactoryOpen);
+        } catch (Exception e) {
+            return new HttpURLConnectionClient(true, null, null);
+        }
+    }
+
+    public HttpURLConnection open(URL url) throws Exception {
+        if (isUsingOkHttp) {
+            return (HttpURLConnection) okUrlFactoryOpen.invoke(okUrlFactory, url);
+        } else {
+            return (HttpURLConnection) url.openConnection();
+        }
+    }
+}


### PR DESCRIPTION
Fix #9 
- overloaded Twitter.signRequest to accept HttpURLConnection
- use OkHttp instead of HttpURLConnection if OkHttp exists in user's classpath

Test:
- Logged all changed code paths to see see that DefaultOAuthConsumer/Provider work,
  HttpURLConnection and OkHttp both work in different dependency settings
- Logs were removed afterwards
