### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download [the latest JAR][latest] or define in Gradle:
 
 ```groovy
 dependencies {
-  compile 'com.parse:parsetwitterutils-android:1.10.3'
+  compile 'com.parse:parsetwitterutils-android:1.10.3@aar'
 }
 ```
 


### PR DESCRIPTION
Simply adding `compile 'com.parse:parsetwitterutils-android:1.10.3'` led to a `Execution failed for task: dexDebug` error after I added the line indicated in the readme. The readme did not go away until I added @aar at the end just like it is with the ParseFacebookUtils gradle import. 

I felt like it should be the same with the Twitter readme so it doesn't fail for sure. Happy to hear your thoughts on this.
