### PR TITLE
Fix HttpURLConnectionClient

### DIFF
--- a/library/src/main/java/com/parse/internal/signpost/basic/HttpURLConnectionClient.java
+++ b/library/src/main/java/com/parse/internal/signpost/basic/HttpURLConnectionClient.java
@@ -1,6 +1,5 @@
 package com.parse.internal.signpost.basic;
 
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -28,7 +27,7 @@ public final class HttpURLConnectionClient {
             final Method okUrlFactoryOpen = okUrlFactoryClass.getMethod("open", URL.class);
             return new HttpURLConnectionClient(true, okUrlFactory, okUrlFactoryOpen);
         } catch (Exception e) {
-            return new HttpURLConnectionClient(true, null, null);
+            return new HttpURLConnectionClient(false, null, null);
         }
     }
 


### PR DESCRIPTION
Correctly use HttpURLConnection if classpath is missing OkHttp.

Fixes issue raised by @tvkkpt: https://github.com/ParsePlatform/ParseTwitterUtils-Android/commit/5cd3788b8d0bb6d7e07d82604a965122d099f40e#commitcomment-15553516
