### PR TITLE
Url to support new policy for android sign-in

### DIFF
--- a/library/src/main/java/com/parse/twitter/Twitter.java
+++ b/library/src/main/java/com/parse/twitter/Twitter.java
@@ -40,7 +40,7 @@ public class Twitter {
   private static final String USER_ID_PARAM = "user_id";
   private static final String SCREEN_NAME_PARAM = "screen_name";
 
-  private static final String CALLBACK_URL = "twitter-oauth://complete";
+  private static final String CALLBACK_URL = "twittersdk://";
 
   // App configuration for enabling authentication.
   private String consumerKey;


### PR DESCRIPTION
So now twitter requires us to whitelist the callback urls on their website as described here: https://twittercommunity.com/t/action-required-sign-in-with-twitter-users-must-whitelist-callback-urls/105342
Because of that users can no longer log in using this library.
Unfortunately website doesn't let us save the current "twitter-oauth://complete" as it doesn't comply with their url validation.
Changing it to "twittersdk://" and also adding this entry in twitter API settings on website helped.